### PR TITLE
[CC-131] Hide TotalWidth and DataWidth to MemoryModule when no DIMM

### DIFF
--- a/hwloc/topology-linux.c
+++ b/hwloc/topology-linux.c
@@ -7145,7 +7145,7 @@ static int dmi_memory_device_total_width(char *buffer, size_t len,
 {
   uint16_t code = *(uint16_t *)(header->tot_width);
 
-  if (code == 0xFFFF)
+  if (code == 0xFFFF || code == 0)
     return -1;
 
   snprintf(buffer, len, "%u", code);
@@ -7157,7 +7157,7 @@ static int dmi_memory_device_data_width(char *buffer, size_t len,
 {
   uint16_t code = *(uint16_t *)(header->dat_width);
 
-  if (code == 0xFFFF)
+  if (code == 0xFFFF || code == 0)
     return -1;
 
   snprintf(buffer, len, "%u", code);
@@ -7169,6 +7169,9 @@ static int dmi_memory_device_speed(char *buffer, size_t len,
 {
   uint16_t code = *(uint16_t *)(header->speed);
 
+  if (code == 0)
+    return -1;
+
   if (code == 0xFFFF) {
     uint32_t code2;
 
@@ -7176,6 +7179,9 @@ static int dmi_memory_device_speed(char *buffer, size_t len,
       return -1;
     
     code2 = *(uint32_t *)(header->extended_size);
+
+    if (code2 == 0)
+       return -1;
     
     snprintf(buffer, len, "%u", code2);
   } else {

--- a/hwloc/topology-linux.c
+++ b/hwloc/topology-linux.c
@@ -7169,9 +7169,6 @@ static int dmi_memory_device_speed(char *buffer, size_t len,
 {
   uint16_t code = *(uint16_t *)(header->speed);
 
-  if (code == 0)
-    return -1;
-
   if (code == 0xFFFF) {
     uint32_t code2;
 
@@ -7179,9 +7176,6 @@ static int dmi_memory_device_speed(char *buffer, size_t len,
       return -1;
     
     code2 = *(uint32_t *)(header->extended_size);
-
-    if (code2 == 0)
-      return -1;
     
     snprintf(buffer, len, "%u", code2);
   } else {

--- a/hwloc/topology-linux.c
+++ b/hwloc/topology-linux.c
@@ -7181,7 +7181,7 @@ static int dmi_memory_device_speed(char *buffer, size_t len,
     code2 = *(uint32_t *)(header->extended_size);
 
     if (code2 == 0)
-       return -1;
+      return -1;
     
     snprintf(buffer, len, "%u", code2);
   } else {


### PR DESCRIPTION
- Hide `TotalWidth` and `DataWidth` to `MemoryModule` when no DIMM
- This change make the field consistent when DIMM is not plugged in and is plugged in. Tested on sr4.
- Sample output
```
...
  Misc(MemoryModule) L#31 (P#31 DeviceLocation=P2-DIMMH2 BankLocation=P1_Node1_Channel3_Dimm1 Vendor="NO DIMM" SerialNumber="NO DIMM" AssetTag="NO DIMM" PartNumber="NO DIMM" FormFactor=DIMM Type=Unknown Size=0 ArrayHandle=0x002b)
```